### PR TITLE
cleanup initial experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To build the examples locally, run:
 
 ```
 npm install
-cd examples && npm install
+cd examples
 npm start
 ```
 
@@ -112,7 +112,7 @@ There are 2 ways:
 1. `const value = this.refs.monaco.editor.model.getValue();`
 
 2. via method of `Model` instance:
- 
+
 ```js
 const model = this.refs.monaco.editor.getModel();
 const value = model.getValue();
@@ -121,4 +121,3 @@ const value = model.getValue();
 # License
 
 MIT, see the [LICENSE](/LICENSE.md) file for detail.
-

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "babel src --out-dir lib",
     "clean": "rimraf lib dist coverage",
     "lint": "eslint src",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "postinstall": "cd examples && npm install && cd .."
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
- ~~drops reference to `tnpm`~~ no longer needed
- use `postinstall` hook to ensure `examples` dependencies are also up-to-date
- updated `README`