### PR TITLE
Add onMonacoAvailable event

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Both them are valid ways to config loader url and relative path of module.
 - `options` refer to [Monaco interface IEditorOptions](https://github.com/Microsoft/monaco-editor/blob/master/website/playground/monaco.d.ts.txt#L1029).
 - `onChange` an event emitted when the content of the current model has changed.
 - `onDidMount` an event emitted when the editor has been mounted (similar to `componentDidMount` of React).
+- `onMonacoAvailable` an event emitted when the monaco top-level object is available. Passes the `monaco` object as the first argument.
 - `requireConfig` optional, using to config loader url and relative path of module, refer to [require.config](http://requirejs.org/docs/api.html#config).
 
 ## Events & Methods

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-monaco-editor",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Monaco Editor for React",
   "main": "lib/index.js",
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -70,9 +70,10 @@ class MonacoEditor extends React.Component {
     }
   }
   initMonaco() {
-    const { value, language, theme, options } = this.props;
+    const { value, language, theme, options, onMonacoAvailable } = this.props;
     const containerElement = this.refs.container;
     if (typeof monaco !== 'undefined') {
+      onMonacoAvailable(monaco);
       this.editor = monaco.editor.create(containerElement, {
         value,
         language,
@@ -106,6 +107,7 @@ MonacoEditor.propTypes = {
   options: PropTypes.object,
   onDidMount: PropTypes.func,
   onChange: PropTypes.func,
+  onMonacoAvailable: PropTypes.func,
   requireConfig: PropTypes.object,
 };
 
@@ -118,6 +120,7 @@ MonacoEditor.defaultProps = {
   options: {},
   onDidMount: noop,
   onChange: noop,
+  onMonacoAvailable: noop,
   requireConfig: {},
 };
 


### PR DESCRIPTION
Some Monaco customizations such as changing language services or add JS libraries for autocomplete ([example](https://microsoft.github.io/monaco-editor/playground.html#extending-language-services-configure-javascript-defaults)) require access to the top-level `monaco` object.

This change adds a new `onMonacoAvailable` event which lets a caller get access to the `monaco` object once it's been loaded in `initMonaco`.