### PR TITLE
Move react deps in dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,11 +48,11 @@
     "eslint-config-rackt": "1.1.0",
     "eslint-plugin-react": "^3.6.3",
     "pre-commit": "^1.1.2",
-    "rimraf": "^2.5.2"
+    "rimraf": "^2.5.2",
+    "react": "^15.1.0",
+    "react-dom": "^15.2.1"
   },
   "dependencies": {
-    "react": "^15.1.0",
-    "react-dom": "^15.2.1",
     "monaco-editor": "~0.7.x"
   },
   "pre-commit": [


### PR DESCRIPTION
A component never force consumer react version, if you want force a dependency on a specific version, use a peerDependency.