### PR TITLE
Updated README with the default value for requiredConfig.path

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ module.exports = {
 };
 ```
 
-Fill `from` field with the actual path of `monaco-editor` package in node_modules.  
+Fill `from` field with the actual path of `monaco-editor` package in node_modules.
 
 ### Using with require.config (do not need Webpack)
 
@@ -129,6 +129,8 @@ class App extends React.Component {
 ```
 
 Both them are valid ways to config loader url and relative path of module.
+
+The default value for `requriedConfig.url` is `vs/loader.js`.
 
 > You may need to note the [cross domain case](https://github.com/Microsoft/monaco-editor#integrate-cross-domain).
 


### PR DESCRIPTION
Knowing the default value can help in the case that Monaco is available on a URL different than `<current_URL>/vs`