### PR TITLE
upgrade to monaco 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
     "rimraf": "^2.5.2"
+  },
   "dependencies": {
     "monaco-editor": "~0.9.x",
     "react": "^15.4.1",

--- a/package.json
+++ b/package.json
@@ -48,12 +48,12 @@
     "eslint-config-rackt": "1.1.0",
     "eslint-plugin-react": "^3.6.3",
     "pre-commit": "^1.1.2",
-    "rimraf": "^2.5.2",
     "react": "^15.4.1",
-    "react-dom": "^15.4.1"
+    "react-dom": "^15.4.1",
+    "rimraf": "^2.5.2"
   },
   "dependencies": {
-    "monaco-editor": "~0.8.x"
+    "monaco-editor": "0.9.0"
   },
   "pre-commit": [
     "lint"

--- a/src/index.js
+++ b/src/index.js
@@ -113,9 +113,9 @@ class MonacoEditor extends React.Component {
       this.editor = context.monaco.editor.create(containerElement, {
         value,
         language,
-        theme,
         ...options,
       });
+      context.monaco.editor.setTheme(theme)
       // After initializing monaco editor
       this.editorDidMount(this.editor, context.monaco);
     }


### PR DESCRIPTION
Addresses #35 

This PR does the following:
- Bumps monaco version
- Replaces deprecated `theme` option

Full monaco-editor 0.9.0 changelog can be found [here](https://github.com/Microsoft/monaco-editor/blob/master/CHANGELOG.md)