### PR TITLE
Move to ESLint's Airbnb config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
 {
-  "extends": "eslint-config-rackt",
+  "parser": "babel-eslint",
+  "extends": "eslint-config-airbnb",
   "rules": {
     "array-bracket-spacing": 0,
     "comma-dangle": 0,
@@ -7,17 +8,20 @@
     // Disable until Flow supports let and const
     "no-var": 0,
     "semi": 0,
+    "no-underscore-dangle": 0,
     "react/jsx-uses-react": 1,
     "react/jsx-no-undef": 2,
-    "react/wrap-multilines": 2
+    "react/jsx-filename-extension": 0,
+    "react/forbid-prop-types": 0,
+    "jsx-a11y/href-no-hash": 0
   },
   "plugins": [
     "react"
   ],
-  "ecmaFeatures": {
-    "jsx": true
-  },
   "globals": {
     "monaco": true
+  },
+  "env": {
+    "browser": true
   }
 }

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,6 +1,9 @@
+/* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import { render } from 'react-dom';
+// eslint-disable-next-line import/no-unresolved, import/extensions
 import MonacoEditor from 'react-monaco-editor';
+/* eslint-enable import/no-extraneous-dependencies */
 
 // Using with webpack
 class CodeEditor extends React.Component {
@@ -10,21 +13,27 @@ class CodeEditor extends React.Component {
       code: '// type your code... \n',
     }
   }
-  editorDidMount(editor) {
+
+  onChange = (newValue, e) => {
+    console.log('onChange', newValue, e); // eslint-disable-line no-console
+  }
+
+  editorDidMount = (editor) => {
+    // eslint-disable-next-line no-console
     console.log('editorDidMount', editor, editor.getValue(), editor.getModel());
     this.editor = editor;
   }
-  onChange(newValue, e) {
-    console.log('onChange', newValue, e);
-  }
-  changeEditorValue() {
+
+  changeEditorValue = () => {
     if (this.editor) {
       this.editor.setValue('// code changed! \n');
     }
   }
-  changeBySetState() {
-    this.setState({code: '// code changed by setState! \n'});
+
+  changeBySetState = () => {
+    this.setState({ code: '// code changed by setState! \n' });
   }
+
   render() {
     const code = this.state.code;
     const options = {
@@ -36,60 +45,61 @@ class CodeEditor extends React.Component {
       automaticLayout: false,
     };
     return (
+      <div>
         <div>
-          <div>
-            <button onClick={::this.changeEditorValue}>Change value</button>
-            <button onClick={::this.changeBySetState}>Change by setState</button>
-          </div>
-          <hr />
-          <MonacoEditor
-              height="500"
-              language="javascript"
-              value={code}
-              options={options}
-              onChange={::this.onChange}
-              editorDidMount={::this.editorDidMount}
-          />
+          <button onClick={this.changeEditorValue}>Change value</button>
+          <button onClick={this.changeBySetState}>Change by setState</button>
         </div>
+        <hr />
+        <MonacoEditor
+          height="500"
+          language="javascript"
+          value={code}
+          options={options}
+          onChange={this.onChange}
+          editorDidMount={this.editorDidMount}
+        />
+      </div>
     );
   }
 }
 
 // Using with require.config
-class AnotherEditor extends React.Component {
+class AnotherEditor extends React.Component { // eslint-disable-line react/no-multi-comp
   constructor(props) {
     super(props);
     const jsonCode = [
       '{',
       '    "$schema": "http://myserver/foo-schema.json"',
-      "}"
+      '}'
     ].join('\n');
     this.state = {
       code: jsonCode,
     }
   }
-  editorWillMount(monaco) {
+
+  editorWillMount = (monaco) => {
     monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
       schemas: [{
-        uri: "http://myserver/foo-schema.json",
+        uri: 'http://myserver/foo-schema.json',
         schema: {
-          type: "object",
+          type: 'object',
           properties: {
             p1: {
-              enum: [ "v1", "v2"]
+              enum: [ 'v1', 'v2']
             },
             p2: {
-              $ref: "http://myserver/bar-schema.json"
+              $ref: 'http://myserver/bar-schema.json'
             }
           }
         }
-      },{
-        uri: "http://myserver/bar-schema.json",
+      }, {
+        uri: 'http://myserver/bar-schema.json',
         schema: {
-          type: "object",
+          type: 'object',
           properties: {
             q1: {
-              enum: [ "x1", "x2"]
+              enum: [ 'x1', 'x2']
             }
           }
         }
@@ -101,39 +111,36 @@ class AnotherEditor extends React.Component {
     const requireConfig = {
       url: 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.1/require.min.js',
       paths: {
-        'vs': 'https://as.alipayobjects.com/g/cicada/monaco-editor-mirror/0.6.1/min/vs'
+        vs: 'https://as.alipayobjects.com/g/cicada/monaco-editor-mirror/0.6.1/min/vs'
       }
     };
     return (
-        <div>
-          <MonacoEditor
-              width="800"
-              height="600"
-              language="json"
-              defaultValue={code}
-              requireConfig={requireConfig}
-              editorWillMount={::this.editorWillMount}
-          />
-        </div>
+      <div>
+        <MonacoEditor
+          width="800"
+          height="600"
+          language="json"
+          defaultValue={code}
+          requireConfig={requireConfig}
+          editorWillMount={this.editorWillMount}
+        />
+      </div>
     );
   }
 }
 
-class App extends React.Component {
-  render() {
-    return (
-        <div>
-          <h2>Monaco Editor Sample (controlled mode)</h2>
-          <CodeEditor />
-          <hr />
-          <h2>Another editor (uncontrolled mode)</h2>
-          <AnotherEditor />
-        </div>
-    );
-  }
-}
+// eslint-disable-next-line react/no-multi-comp
+const App = () => (
+  <div>
+    <h2>Monaco Editor Sample (controlled mode)</h2>
+    <CodeEditor />
+    <hr />
+    <h2>Another editor (uncontrolled mode)</h2>
+    <AnotherEditor />
+  </div>
+)
 
 render(
-    <App />,
-    document.getElementById('root')
+  <App />,
+  document.getElementById('root')
 );

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const webpack = require('webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const path = require('path');

--- a/package.json
+++ b/package.json
@@ -36,24 +36,25 @@
   "homepage": "https://github.com/superRaytin/react-monaco-editor",
   "repository": "https://github.com/superRaytin/react-monaco-editor",
   "devDependencies": {
-    "babel": "^6.5.2",
-    "babel-cli": "^6.10.1",
+    "babel-cli": "^6.24.1",
     "babel-core": "^6.10.4",
-    "babel-eslint": "^6.0.5",
-    "babel-loader": "^6.2.4",
+    "babel-eslint": "^7.2.3",
+    "babel-loader": "^7.1.1",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
-    "babel-preset-stage-0": "^6.5.0",
-    "eslint": "^1.7.1",
-    "eslint-config-rackt": "1.1.0",
-    "eslint-plugin-react": "^3.6.3",
+    "babel-preset-stage-0": "^6.24.1",
+    "eslint": "^4.4.0",
+    "eslint-config-airbnb": "^15.1.0",
+    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-jsx-a11y": "^6.0.2",
+    "eslint-plugin-react": "^7.1.0",
     "pre-commit": "^1.1.2",
-    "rimraf": "^2.5.2",
-    "react": "^15.4.1",
-    "react-dom": "^15.4.1"
+    "rimraf": "^2.5.2"
   },
   "dependencies": {
-    "monaco-editor": "~0.8.x"
+    "monaco-editor": "~0.8.x",
+    "react": "^15.4.1",
+    "react-dom": "^15.4.1"
   },
   "pre-commit": [
     "lint"

--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,18 @@
 import React, { PropTypes } from 'react'
 
-function noop() {}
+function noop() { }
 
 class MonacoEditor extends React.Component {
   constructor(props) {
     super(props);
     this.__current_value = props.value;
   }
+
   componentDidMount() {
     this.afterViewInit();
   }
-  componentWillUnmount() {
-    this.destroyMonaco();
-  }
-  componentDidUpdate(prevProps) {
 
+  componentDidUpdate(prevProps) {
     const context = this.props.context || window;
     if (this.props.value !== this.__current_value) {
       // Always refer to the latest value
@@ -30,25 +28,32 @@ class MonacoEditor extends React.Component {
       context.monaco.editor.setModelLanguage(this.editor.getModel(), this.props.language);
     }
   }
+
+  componentWillUnmount() {
+    this.destroyMonaco();
+  }
+
   editorWillMount(monaco) {
     const { editorWillMount } = this.props;
     editorWillMount(monaco);
   }
+
   editorDidMount(editor, monaco) {
     const { editorDidMount, onChange } = this.props;
     editorDidMount(editor, monaco);
-    editor.onDidChangeModelContent(event => {
+    editor.onDidChangeModelContent((event) => {
       const value = editor.getValue();
-      
+
       // Always refer to the latest value
       this.__current_value = value;
-      
+
       // Only invoking when user input changed
       if (!this.__prevent_trigger_change_event) {
         onChange(value, event);
       }
     });
   }
+
   afterViewInit() {
     const { requireConfig } = this.props;
     const loaderUrl = requireConfig.url || 'vs/loader.js';
@@ -60,7 +65,7 @@ class MonacoEditor extends React.Component {
           context.require.config(requireConfig);
         }
       }
-      
+
       // Load monaco
       context.require(['vs/editor/editor.main'], () => {
         this.initMonaco();
@@ -69,7 +74,7 @@ class MonacoEditor extends React.Component {
       // Call the delayed callbacks when AMD loader has been loaded
       if (context.__REACT_MONACO_EDITOR_LOADER_ISPENDING__) {
         context.__REACT_MONACO_EDITOR_LOADER_ISPENDING__ = false;
-        let loaderCallbacks = context.__REACT_MONACO_EDITOR_LOADER_CALLBACKS__;
+        const loaderCallbacks = context.__REACT_MONACO_EDITOR_LOADER_CALLBACKS__;
         if (loaderCallbacks && loaderCallbacks.length) {
           let currentCallback = loaderCallbacks.shift();
           while (currentCallback) {
@@ -79,33 +84,33 @@ class MonacoEditor extends React.Component {
         }
       }
     };
-    
+
     // Load AMD loader if necessary
     if (context.__REACT_MONACO_EDITOR_LOADER_ISPENDING__) {
-      // We need to avoid loading multiple loader.js when there are multiple editors loading concurrently
-      //  delay to call callbacks except the first one
+      // We need to avoid loading multiple loader.js when there are multiple editors loading
+      // concurrently, delay to call callbacks except the first one
+      // eslint-disable-next-line max-len
       context.__REACT_MONACO_EDITOR_LOADER_CALLBACKS__ = context.__REACT_MONACO_EDITOR_LOADER_CALLBACKS__ || [];
       context.__REACT_MONACO_EDITOR_LOADER_CALLBACKS__.push({
         context: this,
         fn: onGotAmdLoader
       });
+    } else if (typeof context.require === 'undefined') {
+      const loaderScript = context.document.createElement('script');
+      loaderScript.type = 'text/javascript';
+      loaderScript.src = loaderUrl;
+      loaderScript.addEventListener('load', onGotAmdLoader);
+      context.document.body.appendChild(loaderScript);
+      context.__REACT_MONACO_EDITOR_LOADER_ISPENDING__ = true;
     } else {
-      if (typeof context.require === 'undefined') {
-        var loaderScript = context.document.createElement('script');
-        loaderScript.type = 'text/javascript';
-        loaderScript.src = loaderUrl;
-        loaderScript.addEventListener('load', onGotAmdLoader);
-        context.document.body.appendChild(loaderScript);
-        context.__REACT_MONACO_EDITOR_LOADER_ISPENDING__ = true;
-      } else {
-        onGotAmdLoader();
-      }
+      onGotAmdLoader();
     }
   }
+
   initMonaco() {
     const value = this.props.value !== null ? this.props.value : this.props.defaultValue;
     const { language, theme, options } = this.props;
-    const containerElement = this.refs.container;
+    const containerElement = this.refs.container; // eslint-disable-line react/no-string-refs
     const context = this.props.context || window;
     if (typeof context.monaco !== 'undefined') {
       // Before initializing monaco editor
@@ -120,11 +125,13 @@ class MonacoEditor extends React.Component {
       this.editorDidMount(this.editor, context.monaco);
     }
   }
+
   destroyMonaco() {
     if (typeof this.editor !== 'undefined') {
       this.editor.dispose();
     }
   }
+
   render() {
     const { width, height } = this.props;
     const fixedWidth = width.toString().indexOf('%') !== -1 ? width : `${width}px`;
@@ -134,7 +141,8 @@ class MonacoEditor extends React.Component {
       height: fixedHeight,
     };
     return (
-      <div ref="container" style={style} className="react-monaco-editor-container"></div>
+      // eslint-disable-next-line react/no-string-refs
+      <div ref="container" style={style} className="react-monaco-editor-container" />
     )
   }
 }
@@ -157,6 +165,7 @@ MonacoEditor.propTypes = {
   editorWillMount: PropTypes.func,
   onChange: PropTypes.func,
   requireConfig: PropTypes.object,
+  context: PropTypes.object // eslint-disable-line react/require-default-props
 };
 
 MonacoEditor.defaultProps = {


### PR DESCRIPTION
`eslint-config-rackt` is not in development anymore, in fact only a copy on `npmjs.com` does exists, its Github repository is gone.

Moved to `eslint-config-airbnb` and fixed most fo the linter's warnings. 

Some of them, specifically `react/require-default-props` and `react/no-string-refs` will need some refactoring of the code but at the moment it's not necessary.