### PR TITLE
Fix arguments in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ For example, you may want to configure some JSON schemas before editor mounted, 
 
 ```js
 class App extends React.Component {
-    editorWillMount(monaco) {
+    editorWillMount(editor, monaco) {
         monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
             schemas: [{
                 uri: "http://myserver/foo-schema.json",


### PR DESCRIPTION
Also, may be worth adding an example like this:

```ts
    json.setDiagnosticsOptions({
      validate: true,
      schemas: [{
        uri: '*',
        fileMatch: ['*'],
        schema: myFullyDereferencedSchema,
      }],
    });
```
For people who just want their schema without references to start working immediately.