### PR TITLE
Removed jsnext:main from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "files": [
     "lib"
   ],
-  "jsnext:main": "src/index.js",
   "scripts": {
     "build": "babel src --out-dir lib",
     "clean": "rimraf lib dist coverage",


### PR DESCRIPTION
I believe that the current jsnext:main declaration can be a problem, because it points to `src/index.js` which does not exist for projects using react-monaco-editor because only `lib` is published to the npm. (see the files declaration in package.json)

In my case for instance, I am using react-monaco-editor in a project where it breaks the eslint import/no-unresolved rule, because eslint's resolver looks at jsnext:main before looking at main.

I can see 2 ways of fixing this :
- publishing `src` as well
- removing this entry point

I think that the second one is cleaner, and this is what I want to propose here.
What do you think ?