### PR TITLE
Allow users to override loaderUrl and amdRequireBaseUrl even in Electron (refs #75)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Otherwise, it behaves in uncontrolled mode.
 - `onChange(newValue, event)` an event emitted when the content of the current model has changed.
 - `editorWillMount(monaco)` an event emitted before the editor mounted (similar to `componentWillMount` of React).
 - `editorDidMount(editor, monaco)` an event emitted when the editor has been mounted (similar to `componentDidMount` of React).
-- `requireConfig` optional, allow to config loader url and relative path of module, refer to [require.config](http://requirejs.org/docs/api.html#config).
+- `requireConfig` optional, allows configuration of the loader url and relative path of the module. Most properties are the same as those on [require.config](http://requirejs.org/docs/api.html#config). For Electron apps, `requireConfig.baseUrl` can be used to override the path to the folder that contains the `vs` directory, if necessary (defaults to '../node_modules/monaco-editor/min'). For _all_ apps, `requireConfig.url` can be used to override the path to the 'loader.js' file (defaults to 'vs/loader.js' for non-Electron apps, and to '../node_modules/monaco-editor/min/vs/loader.js' for Electron apps).
 - `context` optional, allow to pass a different context then the global window onto which the monaco instance will be loaded. Useful if you want to load the editor in an iframe.
 
 ## Events & Methods

--- a/src/editor.js
+++ b/src/editor.js
@@ -74,7 +74,7 @@ class MonacoEditor extends React.Component {
       // Running in electron, need to deal with the difference between node require and AMDRequire
       // Save a reference to node's require to set back up later
       context.electronNodeRequire = context.require;
-      loaderUrl = '../node_modules/monaco-editor/min/vs/loader.js'
+      loaderUrl = requireConfig.url || '../node_modules/monaco-editor/min/vs/loader.js'
     }
 
     const onGotAmdLoader = () => {
@@ -82,14 +82,18 @@ class MonacoEditor extends React.Component {
         // Do not use webpack
         if (inElectron) {
           // Have just loaded loader.js and now context.require is not node's require
-          const path = context.electronNodeRequire('path');
-          const monacoPath = path.join(context.__dirname, '../node_modules/monaco-editor/min');
+          let amdRequireBaseUrl = requireConfig.baseUrl;
 
-          let amdRequireBaseUrl = path.resolve(monacoPath).replace(/\\/g, '/');
-          if (amdRequireBaseUrl.length > 0 && amdRequireBaseUrl.charAt(0) !== '/') {
-            amdRequireBaseUrl = `/${amdRequireBaseUrl}`;
+          if (!amdRequireBaseUrl) {
+            const path = context.electronNodeRequire('path');
+            const monacoPath = path.join(context.__dirname, '../node_modules/monaco-editor/min');
+
+            let amdRequireBaseUrl = path.resolve(monacoPath).replace(/\\/g, '/');
+            if (amdRequireBaseUrl.length > 0 && amdRequireBaseUrl.charAt(0) !== '/') {
+              amdRequireBaseUrl = `/${amdRequireBaseUrl}`;
+            }
+            amdRequireBaseUrl = encodeURI(`file://${amdRequireBaseUrl}`);
           }
-          amdRequireBaseUrl = encodeURI(`file://${amdRequireBaseUrl}`);
 
           context.require.config({
             baseUrl: amdRequireBaseUrl


### PR DESCRIPTION
This PR is in reference to my comment [here](https://github.com/superRaytin/react-monaco-editor/issues/75#issuecomment-350769720). It allows developers to override certain URLs (`loaderUrl` and `amdRequireBaseUrl`) even in Electron.