### PR TITLE
add next.js example, which uses CommonJS-friendly distribution of monaco editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To build the examples locally, run:
 ```
 npm install
 cd examples/browser && npm install  # or examples/electron, or examples/nextjs
-npm start
+npm start   # or for the next.js example, run `npm run dev`
 ```
 
 Then open `http://localhost:8886` in a browser.

--- a/README.md
+++ b/README.md
@@ -137,16 +137,17 @@ The default value for `requriedConfig.url` is `vs/loader.js`.
 
 > You may need to note the [cross domain case](https://github.com/Microsoft/monaco-editor#integrate-cross-domain).
 
-### Using with @timkendrick/monaco-editor
+### Using with an alternative CommonJS build
 
-If you have a node-like browser environment that conflicts with Monaco's
-loader, you may have more luck with
+If you have a CommonJS-like browser environment, [you may have trouble
+loading monaco-editor](https://github.com/Microsoft/monaco-editor/issues/40).
 [@timkendrick/monaco-editor](https://github.com/timkendrick/monaco-editor)
-which is a CommonJS compatible distribution of monaco-editor. Instructions
-can be found in the project's
-[README](https://github.com/timkendrick/monaco-editor/blob/master/README.md).
+is an unofficial, expiremental build of monaco-editor that loads easily
+into a CommonJS-like environment. Instructions can be found in the
+project's [README](https://github.com/timkendrick/monaco-editor/blob/master/README.md).
 
-The external version is used in the [nextjs example](https://github.com/superRaytin/react-monaco-editor/tree/master/examples/nextjs).
+This is used in the
+[nextjs example](https://github.com/superRaytin/react-monaco-editor/tree/master/examples/nextjs).
 
 ## Properties
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To build the examples locally, run:
 
 ```
 npm install
-cd examples && npm install
+cd examples/browser && npm install  # or examples/electron, or examples/nextjs
 npm start
 ```
 
@@ -136,6 +136,17 @@ Both them are valid ways to config loader url and relative path of module.
 The default value for `requriedConfig.url` is `vs/loader.js`.
 
 > You may need to note the [cross domain case](https://github.com/Microsoft/monaco-editor#integrate-cross-domain).
+
+### Using with @timkendrick/monaco-editor
+
+If you have a node-like browser environment that conflicts with Monaco's
+loader, you may have more luck with
+[@timkendrick/monaco-editor](https://github.com/timkendrick/monaco-editor)
+which is a CommonJS compatible distribution of monaco-editor. Instructions
+can be found in the project's
+[README](https://github.com/timkendrick/monaco-editor/blob/master/README.md).
+
+The external version is used in the [nextjs example](https://github.com/superRaytin/react-monaco-editor/tree/master/examples/nextjs).
 
 ## Properties
 

--- a/examples/nextjs/.babelrc
+++ b/examples/nextjs/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["next/babel"]
+}

--- a/examples/nextjs/components/monaco-editor-wrapper.js
+++ b/examples/nextjs/components/monaco-editor-wrapper.js
@@ -1,0 +1,12 @@
+window.MonacoEnvironment = { baseUrl: '/monaco-editor-external' };
+import * as monaco from '@timkendrick/monaco-editor/dist/external'
+import React, { Component } from 'react'
+import MonacoEditor from 'react-monaco-editor'
+
+export default class MonacoEditorWrapper extends Component {
+  render() {
+    return (
+      <MonacoEditor {...this.props} />
+    )
+  }
+}

--- a/examples/nextjs/next.config.js
+++ b/examples/nextjs/next.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  webpack: (config) => {
+    // Fixes npm packages that depend on `fs` module
+    config.node = {
+      fs: 'empty'
+    }
+
+    return config
+  }
+}

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "react-monaco-editor-nextjs-example",
+  "private": true,
+  "scripts": {
+    "dev": "node server.js",
+    "build": "next build",
+    "start": "NODE_ENV=production node server.js"
+  },
+  "dependencies": {
+    "@timkendrick/monaco-editor": "^0.0.7",
+    "express": "^4.16.2",
+    "next": "^4.2.1",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
+    "react-monaco-editor": "^0.13.0"
+  },
+  "devDependencies": {}
+}

--- a/examples/nextjs/pages/index.js
+++ b/examples/nextjs/pages/index.js
@@ -1,0 +1,33 @@
+import dynamic from 'next/dynamic'
+const MonacoEditorWrapper = dynamic(import('../components/monaco-editor-wrapper'), {ssr: false})
+import Link from 'next/link'
+import Head from 'next/head'
+
+export default () => {
+  const someJs = [
+    "import {myCoolFunc} from './utils'",
+    'export default async () => {',
+    '  await myCoolFunc()',
+    '}'
+  ].join("\n")
+  return (
+    <div>
+      <Head>
+        <link key="monaco-css" rel="stylesheet" href="/monaco-editor-external/monaco.css" />
+      </Head>
+      <div>
+        <Link href="/other-page"><a>Other Page</a></Link>
+      </div>
+      <MonacoEditorWrapper
+        width={500}
+        height={200}
+        language="javascript"
+        theme="vs-dark"
+        value={someJs}
+        options={{selectOnLineNumbers: true}}
+        onChange={() => null}
+        editorDidMount={() => null}
+      />
+    </div>
+  )
+}

--- a/examples/nextjs/pages/other-page.js
+++ b/examples/nextjs/pages/other-page.js
@@ -1,0 +1,49 @@
+import dynamic from 'next/dynamic'
+const MonacoEditorWrapper = dynamic(import('../components/monaco-editor-wrapper'), {ssr: false})
+import Link from 'next/link'
+import Head from 'next/head'
+
+export default () => {
+  const someCss = [
+    '.exampleDiv {',
+    '  background-color: #003;',
+    '  color: #ccc;',
+    '}'
+  ].join("\n")
+  const someJs = [
+    "import {myCoolFunc} from './utils'",
+    'export default async () => {',
+    '  await myCoolFunc()',
+    '}'
+  ].join("\n")
+  return (
+    <div>
+      <Head>
+        <link key="monaco-css" rel="stylesheet" href="/monaco-editor-external/monaco.css" />
+      </Head>
+      <div>
+        <Link href="/"><a>Home</a></Link>
+      </div>
+      <MonacoEditorWrapper
+        width={500}
+        height={200}
+        language="css"
+        theme="vs-dark"
+        value={someCss}
+        options={{selectOnLineNumbers: true}}
+        onChange={() => null}
+        editorDidMount={() => null}
+      />
+      <MonacoEditorWrapper
+        width={500}
+        height={200}
+        language="javascript"
+        theme="vs-dark"
+        value={someJs}
+        options={{selectOnLineNumbers: true}}
+        onChange={() => null}
+        editorDidMount={() => null}
+      />
+    </div>
+  )
+}

--- a/examples/nextjs/server.js
+++ b/examples/nextjs/server.js
@@ -1,0 +1,26 @@
+const express = require('express')
+const next = require('next')
+
+const port = parseInt(process.env.PORT, 10) || 3000
+const dev = process.env.NODE_ENV !== 'production'
+const app = next({ dev })
+const handle = app.getRequestHandler()
+
+app.prepare()
+.then(() => {
+  const server = express()
+
+  server.use(
+    '/monaco-editor-external',
+    express.static(`${__dirname}/node_modules/@timkendrick/monaco-editor/dist/external`)
+  )
+
+  server.get('*', (req, res) => {
+    return handle(req, res)
+  })
+
+  server.listen(port, err => {
+    if (err) throw err
+    console.log(`> Ready on http://localhost:${port}`)
+  })
+})


### PR DESCRIPTION
There are several issues related to using monaco-editor in environments that have node-like globals defined, including  https://github.com/Microsoft/monaco-editor/issues/40. Next.js is such an environment.

It wasn't easy to get monaco-editor working with next.js, with or without react-monaco-editor, and when I did get it working, there were issues with switching pages.

Then I found @timkendrick's [distribution of monaco-editor](https://github.com/timkendrick/monaco-editor) and it worked once I added the CSS file and the global javascript variable.

In this PR is an example, that should work just by running `npm install` and `npm run dev`
  