### PR TITLE
Update monaco-editor to 0.11.1

### DIFF
--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -32,7 +32,7 @@
     "webpack-dev-server": "^2.9.4"
   },
   "dependencies": {
-    "monaco-editor": "^0.10.0",
+    "monaco-editor": "^0.11.1",
     "react": "~16.0.0",
     "react-dom": "^16.0.0",
     "react-monaco-editor": "latest"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react": "^15.x || ^16.x"
   },
   "dependencies": {
-    "monaco-editor": "^0.10.0",
+    "monaco-editor": "^0.11.1",
     "prop-types": "^15.5.10"
   },
   "pre-commit": [

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "babel-eslint": "^8.2.2",
     "babel-loader": "^7.1.2",
     "babel-preset-react": "^6.24.1",
+    "babel-preset-stage-0": "^6.24.1",
     "eslint": "^4.18.1",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-plugin-import": "^2.8.0",


### PR DESCRIPTION
Microsoft released a new version of `monaco-editor`, which includes a number of enhancements to the editor API as well as support for ES modules. This PR updates `react-monaco-editor` to let package users enjoy the editor API enhancements, while leaving the import code as-is. This fixes #101, though a new issue may be needed for the internal cleanup @domoritz described in that issue's conversation.

While working on the repo, I hit a build error due to a dependency on babel's stage0 preset. This PR also adds that to `devDependencies` so that users will be able to run `npm install` without installing other packages.