### PR TITLE
fix `@types/react` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "react": "^15.x || ^16.x"
   },
   "dependencies": {
-    "@types/react": "^16.3.13",
+    "@types/react": "*",
     "monaco-editor": "^0.12.0",
     "prop-types": "^15.6.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -78,9 +78,9 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@types/react@^16.3.13":
-  version "16.3.13"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.13.tgz#47d466462b774556c1174ea0eda22c0578643362"
+"@types/react@*":
+  version "16.3.14"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.14.tgz#f90ac6834de172e13ecca430dcb6814744225d36"
   dependencies:
     csstype "^2.2.0"
 


### PR DESCRIPTION
Fix #121.

I tested `"@types/react": "^15.x || ^16.x"`, and yarn would still install two `@types/react` packages in my project. So I use `"@types/react": "*"` here.