### PR TITLE
Fix some stuff in DiffEditor

### DIFF
--- a/src/diff.js
+++ b/src/diff.js
@@ -51,7 +51,9 @@ class MonacoDiffEditor extends React.Component {
 
   editorWillMount() {
     const { editorWillMount } = this.props;
-    editorWillMount(monaco);
+    if (editorWillMount) {
+      editorWillMount(monaco);
+    }
   }
 
   editorDidMount(editor) {
@@ -84,7 +86,7 @@ class MonacoDiffEditor extends React.Component {
     const { original, theme, options } = this.props;
     if (this.containerElement) {
       // Before initializing monaco editor
-      this.editorWillMount(monaco);
+      this.editorWillMount();
       this.editor = monaco.editor.createDiffEditor(this.containerElement, options);
       if (theme) {
         monaco.editor.setTheme(theme);

--- a/src/diff.js
+++ b/src/diff.js
@@ -32,7 +32,9 @@ class MonacoDiffEditor extends React.Component {
       }
     }
     if (prevProps.language !== this.props.language) {
-      monaco.editor.setModelLanguage(this.editor.getModel(), this.props.language);
+      const { original, modified } = this.editor.getModel();
+      monaco.editor.setModelLanguage(original, this.props.language);
+      monaco.editor.setModelLanguage(modified, this.props.language);
     }
     if (prevProps.theme !== this.props.theme) {
       monaco.editor.setTheme(this.props.theme);


### PR DESCRIPTION
1. If `editorWillMount` es specified as non-existent (null or none), an exception is thrown.
2. [`IStandaloneDiffEditor#getModel()`](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.istandalonediffeditor.html#getmodel) returns an [`IDiffEditorModel`](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.idiffeditormodel.htm`) which is different from `ITextModel` that is accepted by `setModelLanguage`. It has two `ITextModel`s: `original` and `modified`. We have to set the language of both (or we can introduce the ability to have separate languages for each side).
3. `this.editorWillMount` doesn't take an argument, but is called with `monaco`.