### PR TITLE
Add process-size util for better process width and height

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "preversion": "npm run lint",
     "build": "babel src --out-dir lib",
     "clean": "rimraf lib",
-    "format": "prettier-eslint --write src/*",
-    "lint": "prettier-eslint --list-different src/*",
+    "format": "prettier-eslint --write src/**/*",
+    "lint": "prettier-eslint --list-different src/**/*",
     "prepublish": "npm run lint && npm run test && npm run build",
     "test": "npm run test:typescript",
     "test:typescript": "typings-tester --dir test/typescript"

--- a/src/diff.js
+++ b/src/diff.js
@@ -1,8 +1,9 @@
 import * as monaco from 'monaco-editor';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { processSize } from './utils'
 
-function noop() {}
+function noop() { }
 
 class MonacoDiffEditor extends React.Component {
   constructor(props) {
@@ -111,8 +112,8 @@ class MonacoDiffEditor extends React.Component {
 
   render() {
     const { width, height } = this.props;
-    const fixedWidth = width.toString().indexOf('%') !== -1 ? width : `${width}px`;
-    const fixedHeight = height.toString().indexOf('%') !== -1 ? height : `${height}px`;
+    const fixedWidth = processSize(width);
+    const fixedHeight = processSize(height);
     const style = {
       width: fixedWidth,
       height: fixedHeight

--- a/src/editor.js
+++ b/src/editor.js
@@ -1,8 +1,9 @@
 import * as monaco from 'monaco-editor';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { processSize } from './utils'
 
-function noop() {}
+function noop() { }
 
 class MonacoEditor extends React.Component {
   constructor(props) {
@@ -95,8 +96,8 @@ class MonacoEditor extends React.Component {
 
   render() {
     const { width, height } = this.props;
-    const fixedWidth = width.toString().indexOf('%') !== -1 ? width : `${width}px`;
-    const fixedHeight = height.toString().indexOf('%') !== -1 ? height : `${height}px`;
+    const fixedWidth = processSize(width);
+    const fixedHeight = processSize(height);
     const style = {
       width: fixedWidth,
       height: fixedHeight

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,1 @@
+export * from './process-size'

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,1 +1,1 @@
-export * from './process-size'
+export * from './process-size';

--- a/src/utils/process-size.js
+++ b/src/utils/process-size.js
@@ -1,0 +1,3 @@
+export function processSize(size) {
+  return !/^\d+$/.test(size) ? size : `${size}px`;
+}

--- a/src/utils/process-size.js
+++ b/src/utils/process-size.js
@@ -1,3 +1,3 @@
-export default function processSize(size) {
+export function processSize(size) {
   return !/^\d+$/.test(size) ? size : `${size}px`;
 }

--- a/src/utils/process-size.js
+++ b/src/utils/process-size.js
@@ -1,3 +1,3 @@
-export function processSize(size) {
+export default function processSize(size) {
   return !/^\d+$/.test(size) ? size : `${size}px`;
 }


### PR DESCRIPTION
Hey! I like your project that `monaco-editor` very much!
But props of this editor have some problem, if i want to set `height` and `width` to `100px`, in the src,  they are process to `100pxpx`, that's fail! but the editor haven't "throw err" for this condition, It's hard for me to get better error messages to help debug. And sometimes, i want use `rem` or `rm` and other util, but editor can't process, because editor will add 'px' to end, value will to be '100rempx' or `100rmpx` and so on. It's hard to notice without looking at the source code.

I add a small function in util directory. There may be some things that I don't notice, but Enough to solve the problem.

Thank you for your editor, i like it, I want to keep contributing to it.



