### PR TITLE
Only import the editor API instead of the whole package so that Webpack only loads relevant code

### DIFF
--- a/src/diff.js
+++ b/src/diff.js
@@ -1,4 +1,4 @@
-import * as monaco from 'monaco-editor';
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { processSize } from './utils'

--- a/src/editor.js
+++ b/src/editor.js
@@ -1,4 +1,4 @@
-import * as monaco from 'monaco-editor';
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { processSize } from './utils'

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as monacoEditor from "monaco-editor";
+import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api';
 
 export type ChangeHandler = (
   value: string,


### PR DESCRIPTION
As mentioned in https://github.com/Microsoft/monaco-editor-webpack-plugin/issues/43, this package causes Webpack to include the entire Monaco editor codebase in any build, even if only certain languages/features are desired.

With this change, only the core editor is imported, thus slimming down the build size considerably.

Resolves #142 