### PR TITLE
Adds missing property in the component instance for React refs.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -81,7 +81,7 @@ export interface MonacoEditorProps extends MonacoEditorBaseProps {
 }
 
 export default class MonacoEditor extends React.Component<MonacoEditorProps> {
-  editor: monacoEditor.editor.IStandaloneCodeEditor;
+  editor?: monacoEditor.editor.IStandaloneCodeEditor;
 }
 
 // ============ Diff Editor ============

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -81,7 +81,7 @@ export interface MonacoEditorProps extends MonacoEditorBaseProps {
 }
 
 export default class MonacoEditor extends React.Component<MonacoEditorProps> {
-    editor: monacoEditor.editor.IStandaloneCodeEditor;
+  editor: monacoEditor.editor.IStandaloneCodeEditor;
 }
 
 // ============ Diff Editor ============

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -80,7 +80,9 @@ export interface MonacoEditorProps extends MonacoEditorBaseProps {
   onChange?: ChangeHandler;
 }
 
-export default class MonacoEditor extends React.Component<MonacoEditorProps> {}
+export default class MonacoEditor extends React.Component<MonacoEditorProps> {
+    editor: monacoEditor.editor.IStandaloneCodeEditor;
+}
 
 // ============ Diff Editor ============
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -128,4 +128,6 @@ export interface MonacoDiffEditorProps extends MonacoEditorBaseProps {
   onChange?: DiffChangeHandler;
 }
 
-export class MonacoDiffEditor extends React.Component<MonacoDiffEditorProps> {}
+export class MonacoDiffEditor extends React.Component<MonacoDiffEditorProps> {
+  editor?: monacoEditor.editor.IStandaloneDiffEditor;
+}

--- a/test/typescript/editor.tsx
+++ b/test/typescript/editor.tsx
@@ -4,12 +4,15 @@ import MonacoEditor, {
   ChangeHandler,
   EditorWillMount
 } from "../..";
+import * as monacoEditor from "monaco-editor/esm/vs/editor/editor.api";
 
 type AppState = {
   code: string;
 };
 
 class App extends React.Component<{}, AppState> {
+  private editor: MonacoEditor;
+
   state = {
     code: "// type your code..."
   };
@@ -25,6 +28,10 @@ class App extends React.Component<{}, AppState> {
 
   onChange: ChangeHandler = (newValue, e) => {
     console.log("onChange", newValue, e);
+
+    if (this.editor) {
+      const editor: monacoEditor.editor.IStandaloneCodeEditor = this.editor.editor;
+    }
   };
 
   render() {

--- a/test/typescript/editor.tsx
+++ b/test/typescript/editor.tsx
@@ -29,7 +29,7 @@ class App extends React.Component<{}, AppState> {
   onChange: ChangeHandler = (newValue, e) => {
     console.log("onChange", newValue, e);
 
-    if (this.editor) {
+    if (this.editor && this.editor.editor) {
       const editor: monacoEditor.editor.IStandaloneCodeEditor = this.editor.editor;
     }
   };


### PR DESCRIPTION
When creating a ref of the `MonacoEditor`, we need the `editor` property in the component's instance in order for the ref to work.