### PR TITLE
Don't upload yarn-error.log to npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@
 .gitignore
 .npmignore
 .travis.yml
+yarn-error.log


### PR DESCRIPTION
There's a Yarn error log uploaded starting from version 0.21.0

https://cdn.jsdelivr.net/npm/react-monaco-editor@0.21.0/