### PR TITLE
Fix update options in diff

### DIFF
--- a/src/diff.js
+++ b/src/diff.js
@@ -46,6 +46,9 @@ class MonacoDiffEditor extends React.Component {
     ) {
       this.editor.layout();
     }
+    if (prevProps.options !== this.props.options) {
+      this.editor.updateOptions(this.props.options)
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Issue [#156](https://github.com/superRaytin/react-monaco-editor/issues/156) was fixed by PR [#162](https://github.com/superRaytin/react-monaco-editor/pull/162), but only in `editor.js`. This change also propagates the fix to `diff.js`, which is currently still not able to update options.