### PR TITLE
Move monaco to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint-plugin-react": "^7.25.1",
     "eslint-plugin-react-hooks": "^4.2.0",
     "prettier": "^2.4.0",
+    "monaco-editor": "^0.28.1",
     "react": "^17.0.2",
     "rimraf": "^3.0.2",
     "typescript": "^4.4.3"


### PR DESCRIPTION
Fix #351 

Since `monaco-editor-webpack-plugin` has `monaco-editor` as a peer dependency, people will install `monaco-editor` in addition to `react-monaco-editor` and it will bloat the bundle with two different `monaco-editor` (happened in [this PR](https://github.com/integer32llc/rust-playground/pull/736#issuecomment-944512305)) and with possible other problems due to version incompatibility. With peer dependency it forces users to install a `monaco-editor` equal to version needed by this library, and install a compatible `monaco-editor-webpack-plugin`.