### PR TITLE
fix: added condition to handle to fix the broken default value behaviour

### DIFF
--- a/src/editor.tsx
+++ b/src/editor.tsx
@@ -106,7 +106,8 @@ function MonacoEditor(
   useEffect(initMonaco, []);
 
   useEffect(() => {
-    if (editor.current) {
+    // If value is null, we don't want to update the editor content because it is controlled by defaultValue.
+    if (editor.current && value !== null) {
       if (value === editor.current.getValue()) {
         return;
       }


### PR DESCRIPTION
- The default value is not working
- Shows nothing; the defaultValue is passed through the params.
- This pull request makes a small adjustment to the `MonacoEditor` component in `src/editor.tsx` to prevent updating the editor content when the `value` prop is `null`. This ensures the editor content remains controlled by the `defaultValue` in such cases.

![image](https://github.com/user-attachments/assets/0bbe3b40-f3b6-420e-a987-2486c3937949)
![image](https://github.com/user-attachments/assets/e0ffd96f-c578-4215-bd26-834a6b6e5f6c)